### PR TITLE
fix: add deploy with github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+    # Runs on pushes targeting the default branch
+    push:
+        branches: ["master"]
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
+jobs:
+    # Single deploy job since we're just deploying
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+            - name: render index.html
+              run: python3 -m pip install indexage && cd dist && python -m indexage .
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: "."
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/myip.php
+++ b/myip.php
@@ -1,3 +1,0 @@
-<?php
-echo $_SERVER['REMOTE_ADDR'], PHP_EOL;
-?>


### PR DESCRIPTION
Result will be something like that https://n4n5.dev/radvd-project-website-fork/

With the interesting page being https://n4n5.dev/radvd-project-website-fork/dist/

This will be possible if you enable Github actions for deploying the website

<img width="282" height="115" alt="image" src="https://github.com/user-attachments/assets/df60de27-1449-4b52-87d5-a6c4e46924d4" />
